### PR TITLE
feat(security): add TruffleHog secret-scanning pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -180,3 +180,22 @@ repos:
         entry: bash -c 'echo "❌ Decrypted JSON files (.plain.json) must not be committed." && exit 1'
         language: system
         files: \.plain\.json$
+
+  # ============================================================================
+  # Secret Detection - TruffleHog
+  # ============================================================================
+  # Advanced secret detection beyond detect-private-key.
+  # Detects API keys, tokens, credentials, and other secrets.
+  - repo: local
+    hooks:
+      - id: trufflehog
+        name: TruffleHog Secret Scanner
+        description: Detect secrets in your data before committing
+        # Scan staged files only. The git-history mode (--since-commit HEAD) also
+        # traverses fetched remote branches in the local object store, producing
+        # false positives from unmerged branches. Staged-file scanning is the
+        # correct scope for a pre-commit hook; git history scanning belongs in CI.
+        entry: bash -c 'command -v trufflehog >/dev/null 2>&1 && (git diff --cached -z --diff-filter=d --name-only 2>/dev/null | xargs -0 -r trufflehog filesystem --fail --no-update --results=verified,unknown) || echo "TruffleHog not installed - skipping secret scan"'
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]


### PR DESCRIPTION
## Summary

Add a TruffleHog hook scoped to staged files (`git diff --cached |
xargs trufflehog filesystem`). The hook gracefully degrades when TruffleHog
is not installed locally.

See `.claude/rules/pre-commit.md` invariant `PC-HOOK-STAGED-SCOPE` for the
scope principle.

## Why

Resolves observation #4 from `~/.claude/skill-observations/log.md`.
Part of a fleet-wide TruffleHog rollout following the methodology in the
`pre-commit-authoring` skill and the `PC-HOOK-STAGED-SCOPE` invariant in
`.claude/rules/pre-commit.md`.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated secret-scanning to the pre-commit workflow. Staged files are now automatically scanned for secrets before commits are created. Any detected secrets will block the commit from proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->