### PR TITLE
chore(deps): add Renovate rule for org workflow SHA pin updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "description": "Pin GitHub Actions to commit SHA",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "pinDigests": true
+    },
+    {
+      "description": "Track org workflow floating v1 tag for SHA pin updates",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchPackagePatterns": [
+        "ByronWilliamsCPA/.github",
+        "williaby/.github"
+      ],
+      "versioning": "semver",
+      "followTag": "v1"
+    }
+  ]
+}


### PR DESCRIPTION
Adds a packageRules entry so Renovate tracks the v1 floating tag on ByronWilliamsCPA/.github.

CI-056 compliance requirement.

Note: renovate.json was force-added because *.json is in .gitignore; this is intentional for Renovate.