### PR TITLE
chore(security): pin third-party Actions to commit SHAs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -32,7 +32,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Harden the runner (Audit all outbound calls)
-              uses: step-security/harden-runner@v2.12
+              uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
               with:
                   egress-policy: audit
 

--- a/.github/workflows/cifuzzy.yml
+++ b/.github/workflows/cifuzzy.yml
@@ -9,7 +9,7 @@ usage: "Trigger on push to main/develop, pull_request, or manual dispatch"
 behavior: "Sets up environment; builds fuzzers; runs fuzzing; uploads crash artifacts; generates SARIF"
 inputs: "triggers: push(main,develop), pull_request(main,develop), workflow_dispatch; secrets: none"
 outputs: "Crash artifacts under out/artifacts; SARIF report under sarif/cifuzz.sarif"
-dependencies: "step-security/harden-runner@v2.12.0, actions/checkout@v4, google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master, google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master, actions/upload-artifact@v3, github/codeql-action/upload-sarif@v2"
+dependencies: "step-security/harden-runner@v2.12.0, actions/checkout@v4, google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@6353d1276b9505d4df934ae5da6fa616ad1ee273 # master, google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@6353d1276b9505d4df934ae5da6fa616ad1ee273 # master, actions/upload-artifact@v3, github/codeql-action/upload-sarif@8dca8a82e2fa1a2c8908956f711300f9c4a4f4f6 # v2"
 author: "Byron Williams"
 last_modified: "2025-04-17"
 changelog: "Bumped harden-runner, checkout, artifact & SARIF upload actions to latest majors"
@@ -37,21 +37,21 @@ jobs:
       security-events: write
     steps:
       - name: Harden runner (audit outbound)
-        uses: step-security/harden-runner@v2.12
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: audit
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Build Fuzzers
         id: build
-        uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+        uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@6353d1276b9505d4df934ae5da6fa616ad1ee273 # master
         with:
           oss-fuzz-project-name: "ledgerbase"
 
       - name: Run Fuzzers
-        uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+        uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@6353d1276b9505d4df934ae5da6fa616ad1ee273 # master
         with:
           oss-fuzz-project-name: "ledgerbase"
           fuzz-seconds: 600
@@ -59,13 +59,13 @@ jobs:
 
       - name: Upload crash artifacts
         if: failure() && steps.build.outcome == 'success'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@c6a366c94c3e0affe28c06c8df20a878f24da3cf  # v3.2.2
         with:
           name: cifuzz-artifacts
           path: out/artifacts
 
       - name: Upload CIFuzz SARIF
         if: always() && steps.build.outcome == 'success'
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@8dca8a82e2fa1a2c8908956f711300f9c4a4f4f6 # v2
         with:
           sarif_file: sarif/cifuzz.sarif

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -30,12 +30,12 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Harden the runner (Audit all outbound calls)
-              uses: step-security/harden-runner@v2.12
+              uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
               with:
                   egress-policy: audit
 
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
             - name: Dependency Review
-              uses: actions/dependency-review-action@v4
+              uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48  # v4.9.0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,12 +36,12 @@ jobs:
 
         steps:
             - name: Harden the runner (Audit all outbound calls)
-              uses: step-security/harden-runner@v2.12
+              uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
               with:
                   egress-policy: audit
 
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
             - name: Validate GHCR_PAT Secret
               run: |

--- a/.github/workflows/dev-checks.yml
+++ b/.github/workflows/dev-checks.yml
@@ -38,12 +38,12 @@ jobs:
             versions: ${{ steps.load.outputs.versions }}
         steps:
             - name: Harden the runner (Audit all outbound calls)
-              uses: step-security/harden-runner@v2.12
+              uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
               with:
                   egress-policy: audit
 
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
             - name: Install yq
               run: |

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Verify no public PyPI fallbacks
         run: poetry run nox -s verify_assured
@@ -46,7 +46,7 @@ jobs:
         run: poetry run nox -s build_docs
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453  # v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/_build/html

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Verify no public PyPI fallbacks
         run: poetry run nox -s verify_assured
@@ -56,7 +56,7 @@ jobs:
         run: poetry run nox -s license_report
 
       - name: Upload license report artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         if: always()
         with:
           name: license-report
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Verify no public PyPI fallbacks
         run: poetry run nox -s verify_assured

--- a/.github/workflows/prepare-poetry.yml
+++ b/.github/workflows/prepare-poetry.yml
@@ -37,18 +37,18 @@ jobs:
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@v2.12
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: audit
 
       - name: Set up Python
         id: setup-python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.11"
 
       - name: Authenticate to Google Artifact Registry
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@3a3c4c57d294ef65efaaee4ff17b22fa88dd3c69  # v1.3.0
         with:
           credentials_json: ${{ secrets.GCP_SA_JSON }}
 
@@ -60,7 +60,7 @@ jobs:
           pip install poetry
 
       - name: Cache Poetry Dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
         with:
           path: |
             ~/.cache/pypoetry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Verify no public PyPI fallbacks
         run: poetry run nox -s verify_assured

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -43,13 +43,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Verify no public PyPI fallbacks
         run: poetry run nox -s verify_assured
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55  # v2.10.0
 
       - name: Install Trivy & wget
         run: |
@@ -61,7 +61,7 @@ jobs:
         run: poetry run nox -s sbom_validate
 
       - name: Upload SBOM artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: sbom-cyclonedx
           path: docs/generated/sbom/sbom.cdx.json

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -37,17 +37,17 @@ jobs:
 
         steps:
             - name: Harden the runner (Audit all outbound calls)
-              uses: step-security/harden-runner@v2.12
+              uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
               with:
                   egress-policy: audit
 
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
               with:
                   persist-credentials: false
 
             - name: Run Scorecard scan
-              uses: ossf/scorecard-action@v2
+              uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a  # v2.4.3
               with:
                   results_file: results.sarif
                   results_format: sarif
@@ -56,13 +56,13 @@ jobs:
                   # repo_token: ${{ secrets.SCORECARD_TOKEN }}
 
             - name: Upload artifact (SARIF JSON)
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
               with:
                   name: scorecard-sarif
                   path: results.sarif
                   retention-days: 5
 
             - name: Upload to GitHub Code Scanning dashboard
-              uses: github/codeql-action/upload-sarif@v3
+              uses: github/codeql-action/upload-sarif@03e4368ac7daa2bd82b3e85262f3bf87ee112f57  # v3.36.0
               with:
                   sarif_file: results.sarif

--- a/.github/workflows/security-bandit.yml
+++ b/.github/workflows/security-bandit.yml
@@ -44,12 +44,12 @@ jobs:
 
         steps:
             - name: Harden the runner (Audit all outbound calls)
-              uses: step-security/harden-runner@v2.12
+              uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
               with:
                   egress-policy: audit
 
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
             - name: Install SARIF tools
               run: |
@@ -68,7 +68,7 @@ jobs:
                   sarif_file: docs/reports/sarif/bandit.sarif
 
             - name: Summarize Bandit Results in PR
-              uses: actions/github-script@v7.1.0
+              uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0
               with:
                   script: |
                       const fs = require('fs');
@@ -105,7 +105,7 @@ jobs:
 
             - name: Label PR on Bandit Findings
               if: always()
-              uses: actions/github-script@v7.1.0
+              uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0
               with:
                   script: |
                       const fs = require('fs');

--- a/.github/workflows/security-codeql.yml
+++ b/.github/workflows/security-codeql.yml
@@ -68,24 +68,24 @@ jobs:
 
     steps:
       - name: Harden the runner (Audit outbound calls)
-        uses: step-security/harden-runner@v2.12.0
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: audit
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           persist-credentials: false
 
       - name: Set up Python (for Python matrix)
         if: matrix.language == 'python'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache NPM (for JS/TS matrix)
         if: matrix.language == 'javascript-typescript'
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
         with:
           path: |
             ~/.npm
@@ -100,7 +100,7 @@ jobs:
           fi
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@03e4368ac7daa2bd82b3e85262f3bf87ee112f57  # v3.36.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -110,6 +110,6 @@ jobs:
             githubsecuritylab/codeql-${{ matrix.language }}-queries@main
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@03e4368ac7daa2bd82b3e85262f3bf87ee112f57  # v3.36.0
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/security-pip-audit.yml
+++ b/.github/workflows/security-pip-audit.yml
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Verify no public PyPI fallbacks
         run: poetry run nox -s verify_assured
@@ -79,14 +79,14 @@ jobs:
 
       - name: Upload JSON report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: pip-audit-${{ matrix.target.name }}-json
           path: ${{ matrix.target.name }}.json
 
       - name: Upload SARIF report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: pip-audit-${{ matrix.target.name }}-sarif
           path: ${{ matrix.target.name }}.sarif
@@ -94,7 +94,7 @@ jobs:
 
       - name: Upload SARIF to Security tab
         if: always()
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@03e4368ac7daa2bd82b3e85262f3bf87ee112f57  # v3.36.0
         with:
           sarif_file: ${{ matrix.target.name }}.sarif
 
@@ -114,10 +114,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Download JSON report
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: pip-audit-${{ matrix.target.name }}-json
           path: ./reports
@@ -130,7 +130,7 @@ jobs:
 
       - name: Comment PR if issues found
         if: steps.count.outputs.vulns != '0'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0
         with:
           script: |
             const fs = require('fs');
@@ -152,7 +152,7 @@ jobs:
 
       - name: Label PR for pip-audit
         if: steps.count.outputs.vulns != '0'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0
         with:
           script: |
             await github.rest.issues.addLabels({

--- a/.github/workflows/security-semgrep.yml
+++ b/.github/workflows/security-semgrep.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Verify no public PyPI fallbacks
         run: poetry run nox -s verify_assured
@@ -65,6 +65,6 @@ jobs:
 
       - name: Upload Semgrep SARIF (PR only)
         if: github.event_name == 'pull_request'
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@03e4368ac7daa2bd82b3e85262f3bf87ee112f57  # v3.36.0
         with:
           sarif_file: docs/reports/sarif/semgrep-ci.sarif

--- a/.github/workflows/security-snyk.yml
+++ b/.github/workflows/security-snyk.yml
@@ -62,13 +62,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Verify no public PyPI fallbacks
         run: poetry run nox -s verify_assured
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: "20"
           cache: "npm"
@@ -77,13 +77,13 @@ jobs:
         run: poetry run nox -s ${{ matrix.target.session }}
 
       - name: Upload SARIF report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: snyk-${{ matrix.target.name }}-sarif
           path: ${{ matrix.target.sarif }}
           retention-days: 2
 
       - name: Upload SARIF → Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@03e4368ac7daa2bd82b3e85262f3bf87ee112f57  # v3.36.0
         with:
           sarif_file: ${{ matrix.target.sarif }}

--- a/.github/workflows/security-trivy.yml
+++ b/.github/workflows/security-trivy.yml
@@ -45,13 +45,13 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Verify no public PyPI fallbacks
         run: poetry run nox -s verify_assured
 
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@v2.12.0
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: audit
 
@@ -60,7 +60,7 @@ jobs:
           sudo apt-get update && sudo apt-get install -y jq curl
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55  # v2.10.0
 
       - name: Build Docker image with commit SHA tag
         run: docker build -t ledgerbase:${{ github.sha }} .
@@ -86,20 +86,20 @@ jobs:
           echo "vulns=$count" >> $GITHUB_OUTPUT
 
       - name: Upload SARIF to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@03e4368ac7daa2bd82b3e85262f3bf87ee112f57  # v3.36.0
         with:
           sarif_file: docs/reports/sarif/trivy-results.sarif
 
       - name: Upload JSON artifact (includes enriched metadata)
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: trivy-json
           path: docs/reports/json/trivy-results.json
 
       - name: Upload FS/IaC/Secrets scan results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: trivy-fs
           path: docs/reports/fs
@@ -112,7 +112,7 @@ jobs:
 
       - name: Label PR if Trivy issues found
         if: github.event_name == 'pull_request' && steps.count.outputs.vulns != '0'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -31,12 +31,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@v2.12
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: audit
 
       - name: Mark stale issues and PRs
-        uses: actions/stale@v9
+        uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639  # v9.1.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: >

--- a/.github/workflows/templates/assured-oss-auth.yml
+++ b/.github/workflows/templates/assured-oss-auth.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@3a3c4c57d294ef65efaaee4ff17b22fa88dd3c69  # v1.3.0
         with:
           credentials_json: ${{ inputs.credentials_json }}
 
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Verify no public PyPI fallbacks
         shell: bash

--- a/.github/workflows/templates/generate-matrix.yml
+++ b/.github/workflows/templates/generate-matrix.yml
@@ -27,7 +27,7 @@ jobs:
       sessions: ${{ steps.set-matrix.outputs.sessions }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Verify no public PyPI fallback
         run: poetry run nox -s verify_assured

--- a/.github/workflows/templates/lint-matrix.yml
+++ b/.github/workflows/templates/lint-matrix.yml
@@ -28,7 +28,7 @@ jobs:
         session: ${{ fromJson(inputs.sessions) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Verify no public PyPI fallback
         run: poetry run nox -s verify_assured

--- a/.github/workflows/templates/nox-template-matrix.yml
+++ b/.github/workflows/templates/nox-template-matrix.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Verify no public PyPI fallback
         run: poetry run nox -s verify_assured

--- a/.github/workflows/templates/nox-template.yml
+++ b/.github/workflows/templates/nox-template.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Verify no public PyPI fallback
         run: poetry run nox -s verify_assured

--- a/.github/workflows/templates/python-template-pip.yml
+++ b/.github/workflows/templates/python-template-pip.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Verify no public PyPI fallback
         run: poetry run nox -s verify_assured

--- a/.github/workflows/templates/test-matrix.yml
+++ b/.github/workflows/templates/test-matrix.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Verify no public PyPI fallback
         run: poetry run nox -s verify_assured
@@ -39,10 +39,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe  # v5.5.4
         with:
           files: coverage.xml
           flags: tests

--- a/.github/workflows/weekly-check.yml
+++ b/.github/workflows/weekly-check.yml
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Verify no public PyPI fallbacks
         run: poetry run nox -s verify_assured
@@ -99,7 +99,7 @@ jobs:
 
       - name: Upload Aikido SARIF artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: aikido-sarif
           path: aikido.sarif
@@ -115,7 +115,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Verify no public PyPI fallbacks
         run: poetry run nox -s verify_assured
@@ -127,7 +127,7 @@ jobs:
 
       - name: Upload vulture log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: vulture-log
           path: reports/vulture.log
@@ -139,7 +139,7 @@ jobs:
     if: always()
     steps:
       - name: Harden the runner (Audit outbound calls)
-        uses: step-security/harden-runner@v2.12.0
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: audit
 
@@ -156,7 +156,7 @@ jobs:
           npm install -g @microsoft/sarif-multitool jq
 
       - name: Download SARIF artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           path: merged
 
@@ -170,7 +170,7 @@ jobs:
 
       - name: Upload Merged SARIF to GitHub Security Tab
         if: ${{ hashFiles('merged-results.sarif') != '' }}
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@03e4368ac7daa2bd82b3e85262f3bf87ee112f57  # v3.36.0
         with:
           sarif_file: merged-results.sarif
 
@@ -186,7 +186,7 @@ jobs:
 
       - name: Label PR if Security Issues Found
         if: github.event_name == 'pull_request' && steps.check_sarif.outputs.issue_count != '0'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0
         with:
           script: |
             await github.rest.issues.addLabels({

--- a/.github/workflows/wtd.yml
+++ b/.github/workflows/wtd.yml
@@ -38,15 +38,15 @@ jobs:
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@v2.12
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
           egress-policy: audit
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: "20"
           cache: "npm"


### PR DESCRIPTION
## Summary

Converts every tag-pinned third-party GitHub Action in this repo to a 40-character commit SHA pin.

## Why

The tj-actions/changed-files compromise (CVE-2025-30066, March 2025) showed that an attacker who controls an Action's repo can rewrite tag pointers to a malicious commit, retroactively poisoning every consumer pinning by tag. SHA pins are immutable.

## Scope

This is the heaviest of the three high-violation repos in the fleet sweep (76 violations, 27 workflow files). All auto-resolved except three that required manual resolution:

**Auto-converted (script):**
- `actions/cache@v4` -> SHA (v4.3.0)
- `actions/checkout@v4` -> SHA (v4.3.1)
- `actions/dependency-review-action@v4` -> SHA (v4.9.0)
- `actions/download-artifact@v4` -> SHA (v4.3.0)
- `actions/github-script@v7` / `@v7.1.0` -> SHA (v7.1.0)
- `actions/setup-node@v4` -> SHA (v4.4.0)
- `actions/setup-python@v5` -> SHA (v5.6.0)
- `actions/stale@v9` -> SHA (v9.1.0)
- `actions/upload-artifact@v3` / `@v4` -> SHAs (v3.2.2 / v4.6.2)
- `codecov/codecov-action@v5` -> SHA (v5.5.4)
- `docker/setup-buildx-action@v2` -> SHA (v2.10.0)
- `github/codeql-action/analyze@v3` / `init@v3` / `upload-sarif@v3` -> SHA (v3.36.0)
- `google-github-actions/auth@v1` -> SHA (v1.3.0)
- `ossf/scorecard-action@v2` -> SHA (v2.4.3)
- `peaceiris/actions-gh-pages@v4` -> SHA (v4.1.0)
- `step-security/harden-runner@v2.12` / `@v2.12.0` -> SHA (v2.19.4)

**Manually resolved:**
- `github/codeql-action/upload-sarif@v2` (SKIP: no v2 release tag in script) -> `8dca8a82e2fa1a2c8908956f711300f9c4a4f4f6 # v2` (resolved via `gh api repos/github/codeql-action/git/refs/tags/v2`)
- `google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master` (monorepo sub-path, branch ref) -> `6353d1276b9505d4df934ae5da6fa616ad1ee273 # master` (resolved via `gh api repos/google/oss-fuzz/branches/master`)
- `google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master` (same monorepo) -> `6353d1276b9505d4df934ae5da6fa616ad1ee273 # master`

Note: pre-commit hooks (ruff, mypy, bandit, semgrep, vulture, shellcheck, markdownlint) are pre-existing failures on main -- confirmed by running against unmodified HEAD. YAML front-matter validation and all whitespace/encoding hooks pass.

## Maintenance

- williaby/*: Renovate's `pinDigests: true` rule keeps SHAs current. Note: Renovate is currently failing on some williaby repos due to gitPrivateKey errors; see ByronWilliamsCPA/.github#153 for status.

## Test plan

- [ ] CI green on this PR
- [ ] Renovate cycle observed post-merge once auth is restored

Tracking: ByronWilliamsCPA/.github#153 (CI-060)