### PR TITLE
chore(mcp): add context7 and sonarqube MCP servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ sbom.cdx.json
 # Ignore specific directories
 /styles/
 /ledgerbase_secure_env/service-account.json
+
+# Track project MCP server config (exception to *.json)
+!.mcp.json

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,18 @@
+{
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@upstash/context7-mcp@2.2.4"
+      ]
+    },
+    "sonarqube": {
+      "type": "http",
+      "url": "http://localhost:8091/mcp",
+      "headers": {
+        "Authorization": "Bearer ${SONARQUBE_TOKEN}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds project-scoped context7 and sonarqube (org port 8091) MCP servers. Adds a `!.mcp.json` negation to .gitignore so this one file is tracked while the existing `*.json` rule still ignores all other JSON. Config carries no secrets (auth via ${SONARQUBE_TOKEN}). SonarQube endpoint is localhost-bound, matching ByronWilliamsCPA/.claude.